### PR TITLE
add func:  entr_detr_env_moisture_deficit_div

### DIFF
--- a/Turbulence_PrognosticTKE.pxd
+++ b/Turbulence_PrognosticTKE.pxd
@@ -42,6 +42,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         double minimum_area
         double entrainment_factor
         double detrainment_factor
+        double entrainment_Mdiv_factor
         double entrainment_sigma
         double entrainment_smin_tke_coeff
         double entrainment_ed_mf_sigma

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -78,6 +78,8 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                 self.entr_detr_fp = entr_detr_buoyancy_sorting
             elif str(namelist['turbulence']['EDMF_PrognosticTKE']['entrainment']) == 'moisture_deficit':
                 self.entr_detr_fp = entr_detr_env_moisture_deficit
+            elif str(namelist['turbulence']['EDMF_PrognosticTKE']['entrainment']) == 'moisture_deficit_div':
+                self.entr_detr_fp = entr_detr_env_moisture_deficit_div
             elif str(namelist['turbulence']['EDMF_PrognosticTKE']['entrainment']) == 'none':
                 self.entr_detr_fp = entr_detr_none
             else:
@@ -149,6 +151,10 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         self.surface_area = paramlist['turbulence']['EDMF_PrognosticTKE']['surface_area']
         self.max_area = paramlist['turbulence']['EDMF_PrognosticTKE']['max_area']
         self.entrainment_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_factor']
+        try:
+            self.entrainment_Mdiv_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor']
+        except:
+            self.entrainment_Mdiv_factor = 0.0
         self.updraft_mixing_frac = paramlist['turbulence']['EDMF_PrognosticTKE']['updraft_mixing_frac']
         self.entrainment_sigma = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_sigma']
         self.entrainment_smin_tke_coeff = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_smin_tke_coeff']
@@ -1312,6 +1318,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         input.sort_pow = self.sorting_power
         input.c_ent = self.entrainment_factor
         input.c_det = self.detrainment_factor
+        input.c_div = self.entrainment_Mdiv_factor
         input.c_mu = self.entrainment_sigma
         input.c_mu0 = self.entrainment_scale
         input.c_ed_mf = self.entrainment_ed_mf_sigma
@@ -1352,6 +1359,14 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
                     input.nh_pressure = self.nh_pressure[i,k]
                     input.RH_upd = self.UpdVar.RH.values[i,k]
                     input.RH_env = self.EnvVar.RH.values[k]
+
+                    # compute dMdz at half levels
+                    gmv_w_k = interp2pt(GMV.W.values[k], GMV.W.values[k-1])
+                    gmv_w_km = interp2pt(GMV.W.values[k-1], GMV.W.values[k-2])
+                    upd_w_km = interp2pt(self.UpdVar.W.values[i,k-1], self.UpdVar.W.values[i,k-2])
+                    input.M = input.a_upd*(input.w_upd - gmv_w_k)
+                    Mm = self.UpdVar.Area.values[i,k-1]*(upd_w_km - gmv_w_km)
+                    input.dMdz = (input.M - Mm)*self.Gr.dzi
 
                     if self.calc_tke:
                             input.tke = self.EnvVar.TKE.values[k]

--- a/Turbulence_PrognosticTKE.pyx
+++ b/Turbulence_PrognosticTKE.pyx
@@ -152,7 +152,7 @@ cdef class EDMF_PrognosticTKE(ParameterizationBase):
         self.max_area = paramlist['turbulence']['EDMF_PrognosticTKE']['max_area']
         self.entrainment_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_factor']
         try:
-            self.entrainment_Mdiv_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor']
+            self.entrainment_Mdiv_factor = paramlist['turbulence']['EDMF_PrognosticTKE']['entrainment_massflux_div_factor']
         except:
             self.entrainment_Mdiv_factor = 0.0
         self.updraft_mixing_frac = paramlist['turbulence']['EDMF_PrognosticTKE']['updraft_mixing_frac']

--- a/generate_namelist.py
+++ b/generate_namelist.py
@@ -272,6 +272,8 @@ def DryBubble(namelist_defaults):
     namelist['meta']['simname'] = 'DryBubble'
     namelist['meta']['casename'] = 'DryBubble'
 
+    namelist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment'] = 'moisture_deficit_div'
+
     return namelist
 
 def write_file(namelist):

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -47,6 +47,7 @@ def main():
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area'] = 0.9
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_factor'] = 0.13
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 0.51
+    paramlist_defaults['turbelence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor'] = 0.4
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.015
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_ed_mf_sigma'] = 50.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_smin_tke_coeff'] = 0.3
@@ -180,15 +181,10 @@ def SP(paramlist_defaults):
 def DryBubble(paramlist_defaults):
     paramlist = copy.deepcopy(paramlist_defaults)
     paramlist['meta']['casename'] = 'DryBubble'
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_factor'] = 0.2
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 0.3
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.01
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_sigma'] = 5.0
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['surface_area'] = 0.0
 
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area'] = 0.5
-
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_buoy_coeff1'] = 0.1
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_adv_coeff'] = 0.5
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_buoy_coeff1'] = 0.12
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_adv_coeff'] = 0.25
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['pressure_normalmode_drag_coeff'] = 0.1
 
     return  paramlist

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -47,7 +47,7 @@ def main():
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area'] = 0.9
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_factor'] = 0.13
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 0.51
-    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor'] = 0.4
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_massflux_div_factor'] = 0.4
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.015
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_ed_mf_sigma'] = 50.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_smin_tke_coeff'] = 0.3

--- a/generate_paramlist.py
+++ b/generate_paramlist.py
@@ -47,7 +47,7 @@ def main():
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['max_area'] = 0.9
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_factor'] = 0.13
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['detrainment_factor'] = 0.51
-    paramlist_defaults['turbelence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor'] = 0.4
+    paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_Mdiv_factor'] = 0.4
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['turbulent_entrainment_factor'] = 0.015
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_ed_mf_sigma'] = 50.0
     paramlist_defaults['turbulence']['EDMF_PrognosticTKE']['entrainment_smin_tke_coeff'] = 0.3

--- a/turbulence_functions.pxd
+++ b/turbulence_functions.pxd
@@ -18,6 +18,9 @@ cdef struct chi_struct:
     double x1
 
 cdef struct entr_in_struct:
+    double c_div
+    double M
+    double dMdz
     double zi
     double wstar
     double z
@@ -102,6 +105,7 @@ cdef entr_struct entr_detr_inverse_z(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_inverse_w(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_b_w2(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_env_moisture_deficit(entr_in_struct entr_in) nogil
+cdef entr_struct entr_detr_env_moisture_deficit_div(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_env_moisture_deficit_b_ED_MF(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_buoyancy_sorting(entr_in_struct entr_in) nogil
 cdef entr_struct entr_detr_tke(entr_in_struct entr_in) nogil

--- a/turbulence_functions.pyx
+++ b/turbulence_functions.pyx
@@ -110,6 +110,49 @@ cdef entr_struct entr_detr_env_moisture_deficit(entr_in_struct entr_in) nogil:
 
     return _ret
 
+cdef entr_struct entr_detr_env_moisture_deficit_div(entr_in_struct entr_in) nogil:
+    cdef:
+        entr_struct _ret
+        double moisture_deficit_e, moisture_deficit_d, c_det, mu, db, dw, logistic_e, logistic_d, ed_mf_ratio, bmix
+        double l[2]
+
+    moisture_deficit_d = (fmax((entr_in.RH_upd/100.0)**entr_in.sort_pow-(entr_in.RH_env/100.0)**entr_in.sort_pow,0.0))**(1.0/entr_in.sort_pow)
+    moisture_deficit_e = (fmax((entr_in.RH_env/100.0)**entr_in.sort_pow-(entr_in.RH_upd/100.0)**entr_in.sort_pow,0.0))**(1.0/entr_in.sort_pow)
+    _ret.sorting_function = moisture_deficit_e
+    c_det = entr_in.c_det
+    if (entr_in.ql_up+entr_in.ql_env)==0.0:
+        c_det = 0.0
+
+    dw   = entr_in.w_upd - entr_in.w_env
+    if dw < 0.0:
+        dw -= 0.001
+    else:
+        dw += 0.001
+
+    db = (entr_in.b_upd - entr_in.b_env)
+    mu = entr_in.c_mu/entr_in.c_mu0
+
+    inv_timescale = fabs(db/dw)
+    logistic_e = 1.0/(1.0+exp(-mu*db/dw*(entr_in.chi_upd - entr_in.a_upd/(entr_in.a_upd+entr_in.a_env))))
+    logistic_d = 1.0/(1.0+exp( mu*db/dw*(entr_in.chi_upd - entr_in.a_upd/(entr_in.a_upd+entr_in.a_env))))
+
+    entr_MdMdz = fmax( entr_in.dMdz/fmax(entr_in.M,1e-12),0.0)
+    detr_MdMdz = fmax(-entr_in.dMdz/fmax(entr_in.M,1e-12),0.0)
+
+
+    #smooth min
+    with gil:
+        l[0] = entr_in.tke_coef*fabs(db/sqrt(entr_in.tke+1e-8))
+        l[1] = fabs(db/dw)
+        inv_timescale = lamb_smooth_minimum(l, 0.1, 0.0005)
+
+    _ret.entr_sc = inv_timescale/dw*(entr_in.c_ent*logistic_e + c_det*moisture_deficit_e) + entr_MdMdz * entr_in.c_div
+    _ret.detr_sc = inv_timescale/dw*(entr_in.c_ent*logistic_d + c_det*moisture_deficit_d) + detr_MdMdz * entr_in.c_div
+
+
+    return _ret
+
+
 cdef entr_struct entr_detr_buoyancy_sorting(entr_in_struct entr_in) nogil:
 
     cdef:


### PR DESCRIPTION
in turbulence_functions.pyx:  entr_detr_env_moisture_deficit_div that adds 1/M dM/dz on top of the fractional entrainment/detrainment calculated by entr_detr_env_moisture_deficit

this function is called by setting the 'entrainment' namelist option as 'moisture_deficit_div'